### PR TITLE
Handle error condition when a Comet Dect device looses connection to the Fritzbox

### DIFF
--- a/check_fbox_smarthome.php
+++ b/check_fbox_smarthome.php
@@ -560,10 +560,9 @@ function do_fbox_command ($fboxname="", $fboxhost="", $fboxlogin="", $fboxpw="",
     #     hence the making-sure of having a non-null value even for null information from the fbox actors information.
     if ( (!isset($temperature)) and (!isset($switchstatus)) and (!isset($actorinfo['powermeter']['power'])) and (!isset($actorinfo['powermeter']['energy'])) )
     {
-      dbgprint ("dbg", "get_data", "Got insufficient information from actor device " .$actorinfo['name']. " in section $fboxname.. Skipping the rest.");
-      # TODO this happens when a Comet Dect device looses the connection to the Fritzbox
+      dbgprint ("dbg", "get_data", "Got insufficient information from actor device " .$actorinfo['name']. " in section $fboxname..");
+      # this happens eg. when a Comet Dect device looses the connection to the Fritzbox
       # we need to give a WARNING, instead of just moving to the next device
-      continue;
     }
 
     # prepare output

--- a/check_fbox_smarthome.php
+++ b/check_fbox_smarthome.php
@@ -536,8 +536,8 @@ function do_fbox_command ($fboxname="", $fboxhost="", $fboxlogin="", $fboxpw="",
     $battery         = (isset($actorinfo['battery'])) ? floor($actorinfo['battery']) : null;
     $batterylow      = (isset($actorinfo['batterylow'])) ? floor($actorinfo['batterylow']) : null;
     # ie. 193 => 19.3 deg Celsius
-    $temperature     = (isset($actorinfo['temperature']['celsius'])) ? floor($actorinfo['temperature']['celsius']) / 10 : null;
-    $tempoffset      = (isset($actorinfo['temperature']['offset'])) ? floor($actorinfo['temperature']['offset']) / 10 : null;
+    $temperature     = (isset($actorinfo['temperature']['celsius']) && is_numeric($actorinfo['temperature']['celsius'])) ? floor($actorinfo['temperature']['celsius']) / 10 : null;
+    $tempoffset      = (isset($actorinfo['temperature']['offset']) && is_numeric($actorinfo['temperature']['celsius'])) ? floor($actorinfo['temperature']['offset']) / 10 : null;
     if ($use_tempoffset == true) { $temperature = $temperature + $tempoffset; }
     # either 0 or 1
     $switchstatus    = (isset($actorinfo['switch']['state'])) ? (floor($actorinfo['switch']['state']) > 0 ? 1 : 0) : null;
@@ -561,6 +561,8 @@ function do_fbox_command ($fboxname="", $fboxhost="", $fboxlogin="", $fboxpw="",
     if ( (!isset($temperature)) and (!isset($switchstatus)) and (!isset($actorinfo['powermeter']['power'])) and (!isset($actorinfo['powermeter']['energy'])) )
     {
       dbgprint ("dbg", "get_data", "Got insufficient information from actor device " .$actorinfo['name']. " in section $fboxname.. Skipping the rest.");
+      # TODO this happens when a Comet Dect device looses the connection to the Fritzbox
+      # we need to give a WARNING, instead of just moving to the next device
       continue;
     }
 

--- a/check_fbox_smarthome.php
+++ b/check_fbox_smarthome.php
@@ -435,8 +435,12 @@ function get_actor_infos ($url)
       {
         $ident = $actor['@attributes']['identifier'];
         $name = $actor['name'];
-        dbgprint ("dbg", "get_actor_infos", "found actor: '$name' (ident:$ident)");
-        $actorident2infos[$ident] = $actor;
+		$manufacturer = $actor['@attributes']['manufacturer'];
+		$productname = $actor['@attributes']['productname'];
+		if ($manufacturer != '0x0000' && $name != '') {
+          dbgprint ("dbg", "get_actor_infos", "found actor: '$name' (ident:$ident)");
+          $actorident2infos[$ident] = $actor;
+        }
       }
     }
   } # end if got actors returned


### PR DESCRIPTION
When a Comet Dect device looses connection to the Fritzbox, the plugin would crash on an empty string for the temperature. Also, we need to keep devices in the list, when when no data can be gathered, so the plugin can issue a warning that they aren't currently present.